### PR TITLE
(fix) meta properties for charset and viewport

### DIFF
--- a/app/common/get-meta-tags.ts
+++ b/app/common/get-meta-tags.ts
@@ -13,8 +13,14 @@ export function getMetaTags(tags: MetaTags) {
 
   const metaTags = [
     { title: tags.title },
-    { charset: 'utf-8' },
-    { viewport: 'width=device-width,initial-scale-1' },
+    {
+      name: 'charset',
+      content: 'utf-8',
+    },
+    {
+      name: 'viewport',
+      content: 'width=device-width,initial-scale-1',
+    },
     {
       name: 'description',
       content: tags.description,


### PR DESCRIPTION
I had improperly added the charset and viewport meta properties in our function that helps build the meta tags for each page. This fixes the scaling on mobile sized devices.