### PR TITLE
Add Navigation to Parallel Bible Verse Pages

### DIFF
--- a/app/api/interfaces.ts
+++ b/app/api/interfaces.ts
@@ -297,7 +297,7 @@ export interface BibleChapter {
   translationName: string;
   json: string;
   streamUrl?: string;
-  // verses: Verse[];
+  verses: BibleVerse[];
   // book: Book;
   // footnotes: Footnote[];
   nextChapterNumber?: number;

--- a/app/components/bible-verse-parallel.tsx
+++ b/app/components/bible-verse-parallel.tsx
@@ -1,14 +1,151 @@
-import { BibleParallel } from '~/api/interfaces';
+import { BibleChapter, BibleParallel } from '~/api/interfaces';
 import { Link } from '@remix-run/react';
-import React from 'react';
+import { IconContext } from 'react-icons';
+import {
+  FaRegArrowAltCircleLeft,
+  FaRegArrowAltCircleRight,
+} from 'react-icons/fa';
+import { OsisToBookName } from '~/common/bible-constants';
+import { ChapterData, ChapterContent, ChapterVerse } from '~/api/bible.types';
 
 export interface BibleVerseParallelProps {
   parallels: BibleParallel;
+  chapterData: BibleChapter;
+  previousChapterData: BibleChapter | null;
 }
 
-export const BibleVerseParallel = ({ parallels }: BibleVerseParallelProps) => {
+interface VerseNavigation {
+  previousBook: string | null;
+  previousChapter: number | null;
+  previousVerse: number | null;
+  nextBook: string | null;
+  nextChapter: number | null;
+  nextVerse: number | null;
+  isFirstVerseOfGenesis: boolean;
+  isLastVerseOfRevalation: boolean;
+}
+
+function calculateVerseNavigation(
+  book: string,
+  chapter: number,
+  verse: number,
+  chapterData: BibleChapter,
+  previousChapterData: BibleChapter | null,
+): VerseNavigation {
+
+  let previousBook: string | null = null;
+  let previousChapter: number | null = null;
+  let previousVerse: number | null = null;
+  let nextBook: string | null = null;
+  let nextChapter: number | null = null;
+  let nextVerse: number | null = null;
+  let isFirstVerseOfGenesis: boolean;
+  let isLastVerseOfRevalation: boolean;
+
+  isFirstVerseOfGenesis = false;
+  isLastVerseOfRevalation = false;
+
+  if (book === 'GEN' && chapter === 1 && verse === 1) {
+    isFirstVerseOfGenesis = true;
+  }
+
+  if (book === 'REV' && chapter === 22 && verse === 21) {
+    isLastVerseOfRevalation = true;
+  }
+
+  // Defaults
+  previousBook = book;
+  previousChapter = chapter;
+  nextBook = book;
+  nextChapter = chapter;
+
+  if (verse === 1) {
+    previousVerse = previousChapterData?.verses.length - 1;
+    previousBook = chapterData.previousBookId;
+    previousChapter = chapterData.previousChapterNumber;
+  } else {
+    previousVerse = verse - 1;
+  }
+
+  if (verse === chapterData.verses.length - 1) {
+    nextVerse = 1;
+    nextBook = chapterData.nextBookId;
+    nextChapter = chapterData.nextChapterNumber;
+  } else {
+    nextVerse = verse + 1;
+  }
+
+  return {
+    previousBook,
+    previousChapter,
+    previousVerse,
+    nextBook,
+    nextChapter,
+    nextVerse,
+    isFirstVerseOfGenesis,
+    isLastVerseOfRevalation
+  };
+}
+
+export const BibleVerseParallel = ({ parallels, chapterData, previousChapterData }: BibleVerseParallelProps) => {
+  const contextData = JSON.parse(parallels.contextJson);
+  const navigation = calculateVerseNavigation(
+    parallels.book,
+    parallels.chapter,
+    parallels.verse,
+    chapterData,
+    previousChapterData,
+  );
+
+  const reference = `${OsisToBookName[parallels.book as keyof typeof OsisToBookName]
+    } ${parallels.chapter}:${parallels.verse}`;
+
+  // Build previous verse URL
+  const previousUrl = navigation.previousBook && navigation.previousChapter && navigation.previousVerse
+    ? `/bible/parallel/${navigation.previousBook}/${navigation.previousChapter}/${navigation.previousVerse}`
+    : '#';
+
+  // Build next verse URL  
+  const nextUrl = navigation.nextBook && navigation.nextChapter && navigation.nextVerse
+    ? `/bible/parallel/${navigation.nextBook}/${navigation.nextChapter}/${navigation.nextVerse}`
+    : '#';
+
   return (
     <div>
+      {/* Browse Links */}
+      <div className="flex w-full min-h-16 items-center justify-center space-x-14 md:space-x-24 mb-4">
+
+        {!navigation.isFirstVerseOfGenesis && (
+          <Link to={previousUrl} >
+            <IconContext.Provider
+              value={{
+                className:
+                  'w-6 h-6 md:w-7 md:h-7 text-neutral-600 dark:text-neutral-200',
+              }}
+            >
+              <FaRegArrowAltCircleLeft />
+            </IconContext.Provider>
+          </Link>
+        )}
+
+        <span className="text-2xl md:text-3xl text-center">{reference}</span>
+
+        {!navigation.isLastVerseOfRevalation && (
+          <Link to={nextUrl} >
+            <IconContext.Provider
+              value={{
+                className:
+                  'w-6 h-6 md:w-7 md:h-7 text-neutral-600 dark:text-neutral-200',
+              }}
+            >
+              <FaRegArrowAltCircleRight />
+            </IconContext.Provider>
+          </Link>
+        )}
+
+      </div>
+
+      {/* Verse Translations */}
       {parallels.verses.map((verse, index) => {
         return (
           <div key={index} className="py-1 px-2">

--- a/app/routes/bible_.parallel.$book.$chapter_.$verse.tsx
+++ b/app/routes/bible_.parallel.$book.$chapter_.$verse.tsx
@@ -3,6 +3,7 @@ import { Link, MetaFunction, useLoaderData } from '@remix-run/react';
 import { useState } from 'react';
 import { ChapterData } from '~/api/bible.types';
 import {
+  BibleChapter,
   BibleParallel,
   CommentaryVerse,
   ListPaginatedResponse,
@@ -40,7 +41,8 @@ export async function loader({ params }: LoaderFunctionArgs) {
   const { book, chapter, verse } = params;
   const bookId = getBibleBookId(book);
 
-  const [parallels, sermons, commentaries] = await Promise.all([
+  // Prepare API calls for navigation data
+  const apiCalls = [
     // translations=BSB,KJV,ASV,WEB,YLT,BBE,DRV,GNV,T4T,OUR,FBV,PEV,ULB,WBS,LST
     fetchApi<BibleParallel>(
       `/bible/eng/parallel/${bookId}/${chapter}/${verse}?translations=BSB,eng_kjv,eng_asv,eng_webp,eng_ylt,eng_bbe,eng_drv,eng_gnv,eng_t4t,eng_our,eng_fbv,eng_pev,eng_ulb,eng_wbs,eng_lst`,
@@ -51,25 +53,48 @@ export async function loader({ params }: LoaderFunctionArgs) {
     fetchApi<ListResponse<CommentaryVerse>>(
       `/commentary/eng/parallel/${bookId}/${chapter}/${verse}`,
     ),
-  ]);
+    // Hardcoded BSB for now. Would be good to include this in parallel contextJson
+    fetchApi<BibleChapter>(
+      `/bible/eng/BSB/${bookId}/${chapter}`
+    ),
+  ];
+
+  const [parallels, sermons, commentaries, chapterData] = await Promise.all(apiCalls);
 
   if (
     'statusCode' in parallels ||
     'statusCode' in sermons ||
-    'statusCode' in commentaries
+    'statusCode' in commentaries ||
+    'statusCode' in chapterData
+
   ) {
     throw new Response('Oh no! Something went wrong!', {
       status: 500,
     });
   }
 
-  return { parallels, sermons, commentaries };
+  // Add previous chapter API call if it exists
+  let previousChapterDataPromise = null;
+  if (chapterData.previousBookId && chapterData.previousChapterNumber) {
+    previousChapterDataPromise = fetchApi<BibleChapter>(`/bible/eng/BSB/${chapterData.previousBookId}/${chapterData.previousChapterNumber}`);
+  }
+
+  // Fetch previous and next chapter data if needed
+  let previousChapterData = null;
+
+  if (previousChapterDataPromise) {
+    previousChapterData = await previousChapterDataPromise;
+    if ('statusCode' in previousChapterData) {
+      previousChapterData = null; // Handle gracefully
+    }
+  }
+
+  return { parallels, sermons, commentaries, chapterData, previousChapterData };
 }
 
 export const meta: MetaFunction<typeof loader> = ({ data, params }) => {
-  const reference = `${
-    OsisToBookName[data?.parallels.book as keyof typeof OsisToBookName]
-  } ${data?.parallels.chapter}:${data?.parallels.verse}`;
+  const reference = `${OsisToBookName[data?.parallels.book as keyof typeof OsisToBookName]
+    } ${data?.parallels.chapter}:${data?.parallels.verse}`;
   const verse =
     data?.parallels.verses.find((v) => v.translationId === 'BSB')?.text || '';
 
@@ -84,7 +109,7 @@ export const meta: MetaFunction<typeof loader> = ({ data, params }) => {
 };
 
 export default function Index() {
-  const { parallels, sermons, commentaries } = useLoaderData<typeof loader>();
+  const { parallels, sermons, commentaries, chapterData, previousChapterData } = useLoaderData<typeof loader>();
   const verseContext = JSON.parse(parallels.contextJson) as ChapterData;
 
   const [activeTab, setActiveTab] = useState(Tabs.Scripture);
@@ -93,29 +118,10 @@ export default function Index() {
     <SiPage>
       {/* Desktop View */}
       <div className="w-full hidden lg:block pb-8">
-        <h1 className="flex w-full text-2xl md:text-3xl items-center justify-center">
-          {OsisToBookName[parallels.book as keyof typeof OsisToBookName]}{' '}
-          {parallels.chapter}:{parallels.verse}
-        </h1>
-
         <div className="grid grid-cols-3">
           <div className="col-span-2">
             <SiSection title="Verse">
-              {parallels.verses.map((verse, index) => {
-                return (
-                  <div key={index} className="py-1 px-2">
-                    {/* TODO: LINK TRANSLATION NAME TO CHAPTER PAGE */}
-                    <Link
-                      to={`/bible/${verse.translationId}/${parallels.book}/${parallels.chapter}`}
-                    >
-                      <span className="text-si-main dark:text-si-brown hover:underline hover:cursor-pointer">
-                        {verse.translationName}
-                      </span>
-                    </Link>
-                    <div>{verse.text}</div>
-                  </div>
-                );
-              })}
+              <BibleVerseParallel parallels={parallels} chapterData={chapterData} previousChapterData={previousChapterData} />
             </SiSection>
           </div>
           <div>
@@ -192,7 +198,7 @@ export default function Index() {
             active={activeTab === Tabs.Scripture}
             className="py-4 px-2 md:p-4"
           >
-            <BibleVerseParallel parallels={parallels} />
+            <BibleVerseParallel parallels={parallels} chapterData={chapterData} previousChapterData={previousChapterData} />
           </TabContent>
 
           {/* <TabContent


### PR DESCRIPTION
This PR adds navigation links to the parallel bible verse pages, much like already exists for chapters.

https://github.com/orgs/sermonindex/projects/1/views/1?pane=issue&itemId=100025711&issue=sermonindex%7Csi-poc%7C64

<img width="1624" height="1231" alt="Screenshot From 2025-08-28 09-25-57" src="https://github.com/user-attachments/assets/90c9eeca-656d-4369-bee0-8130f69e85ef" />
