### PR TITLE
DRAFT: (fix) verse context state

### DIFF
--- a/app/common/verse-navigation.ts
+++ b/app/common/verse-navigation.ts
@@ -1,0 +1,74 @@
+import {BibleChapter} from "~/api/interfaces";
+
+export interface VerseNavigation {
+    previousBook: string | null;
+    previousChapter: number | null;
+    previousVerse: number | null;
+    nextBook: string | null;
+    nextChapter: number | null;
+    nextVerse: number | null;
+    isFirstVerseOfGenesis: boolean;
+    isLastVerseOfRevalation: boolean;
+}
+
+export function calculateVerseNavigation(
+    book: string,
+    chapter: number,
+    verse: number,
+    chapterData: BibleChapter,
+    previousChapterData: BibleChapter | null,
+): VerseNavigation {
+
+    let previousBook: string | null = null;
+    let previousChapter: number | null = null;
+    let previousVerse: number | null = null;
+    let nextBook: string | null = null;
+    let nextChapter: number | null = null;
+    let nextVerse: number | null = null;
+    let isFirstVerseOfGenesis: boolean;
+    let isLastVerseOfRevalation: boolean;
+
+    isFirstVerseOfGenesis = false;
+    isLastVerseOfRevalation = false;
+
+    if (book === 'GEN' && chapter === 1 && verse === 1) {
+        isFirstVerseOfGenesis = true;
+    }
+
+    if (book === 'REV' && chapter === 22 && verse === 21) {
+        isLastVerseOfRevalation = true;
+    }
+
+    // Defaults
+    previousBook = book;
+    previousChapter = chapter;
+    nextBook = book;
+    nextChapter = chapter;
+
+    if (verse === 1) {
+        previousVerse = previousChapterData?.verses.length - 1;
+        previousBook = chapterData.previousBookId;
+        previousChapter = chapterData.previousChapterNumber;
+    } else {
+        previousVerse = verse - 1;
+    }
+
+    if (verse === chapterData.verses.length - 1) {
+        nextVerse = 1;
+        nextBook = chapterData.nextBookId;
+        nextChapter = chapterData.nextChapterNumber;
+    } else {
+        nextVerse = verse + 1;
+    }
+
+    return {
+        previousBook,
+        previousChapter,
+        previousVerse,
+        nextBook,
+        nextChapter,
+        nextVerse,
+        isFirstVerseOfGenesis,
+        isLastVerseOfRevalation
+    };
+}

--- a/app/components/bible-verse-context.tsx
+++ b/app/components/bible-verse-context.tsx
@@ -72,12 +72,6 @@ export const VerseContext = ({
 
   return (
     <div className={outerPadding}>
-      {!slim && (
-        <h1 className="text-2xl md:text-3xl">
-          {OsisToBookName[book as keyof typeof OsisToBookName]} {chapterNumber}:
-          {verseNumber}
-        </h1>
-      )}
       <h2
         id="context-heading"
         className="mb-1 text-neutral-500 dark:text-neutral-400"

--- a/app/components/bible-verse-navigator.tsx
+++ b/app/components/bible-verse-navigator.tsx
@@ -1,0 +1,61 @@
+import { Link } from '@remix-run/react';
+import { IconContext } from 'react-icons';
+import {
+    FaRegArrowAltCircleLeft,
+    FaRegArrowAltCircleRight,
+} from 'react-icons/fa';
+import { OsisToBookName } from '~/common/bible-constants';
+
+export interface VerseNavigatorProps {
+    book: string;
+    chapter: number;
+    verse: number;
+    previousUrl: string;
+    nextUrl: string;
+    showPrevious: boolean;
+    showNext: boolean;
+}
+
+export function VerseNavigator({
+                                   book,
+                                   chapter,
+                                   verse,
+                                   previousUrl,
+                                   nextUrl,
+                                   showPrevious,
+                                   showNext,
+                               }: VerseNavigatorProps) {
+    const iconContextValue = {
+        className: 'w-6 h-6 md:w-7 md:h-7 text-neutral-600 dark:text-neutral-200 hover:text-si-main dark:hover:text-si-brown',
+    };
+
+    return (
+        <div className="flex w-full min-h-16 items-center justify-center gap-x-8 md:gap-x-12 mb-4">
+            {showPrevious ? (
+                <Link to={previousUrl} prefetch="intent" title="Previous Verse">
+                    <IconContext.Provider value={iconContextValue}>
+                        <FaRegArrowAltCircleLeft />
+                    </IconContext.Provider>
+                </Link>
+            ) : (
+                // Add a placeholder to maintain balance when one arrow is hidden
+                <div className="w-6 md:w-7" />
+            )}
+
+            <h1 className="text-2xl md:text-3xl text-center whitespace-nowrap">
+                {OsisToBookName[book as keyof typeof OsisToBookName]} {chapter}:{verse}
+            </h1>
+
+            {showNext ? (
+                <Link to={nextUrl} prefetch="intent" title="Next Verse">
+                    <IconContext.Provider value={iconContextValue}>
+                        <FaRegArrowAltCircleRight />
+                    </IconContext.Provider>
+                </Link>
+            ) : (
+                // Add a placeholder to maintain balance when one arrow is hidden
+                <div className="w-6 md:w-7" />
+            )}
+        </div>
+    );
+}

--- a/app/components/bible-verse-parallel.tsx
+++ b/app/components/bible-verse-parallel.tsx
@@ -1,150 +1,13 @@
-import { BibleChapter, BibleParallel } from '~/api/interfaces';
+import { BibleParallel } from '~/api/interfaces';
 import { Link } from '@remix-run/react';
-import { IconContext } from 'react-icons';
-import {
-  FaRegArrowAltCircleLeft,
-  FaRegArrowAltCircleRight,
-} from 'react-icons/fa';
-import { OsisToBookName } from '~/common/bible-constants';
-import { ChapterData, ChapterContent, ChapterVerse } from '~/api/bible.types';
 
 export interface BibleVerseParallelProps {
   parallels: BibleParallel;
-  chapterData: BibleChapter;
-  previousChapterData: BibleChapter | null;
 }
 
-interface VerseNavigation {
-  previousBook: string | null;
-  previousChapter: number | null;
-  previousVerse: number | null;
-  nextBook: string | null;
-  nextChapter: number | null;
-  nextVerse: number | null;
-  isFirstVerseOfGenesis: boolean;
-  isLastVerseOfRevalation: boolean;
-}
-
-function calculateVerseNavigation(
-  book: string,
-  chapter: number,
-  verse: number,
-  chapterData: BibleChapter,
-  previousChapterData: BibleChapter | null,
-): VerseNavigation {
-
-  let previousBook: string | null = null;
-  let previousChapter: number | null = null;
-  let previousVerse: number | null = null;
-  let nextBook: string | null = null;
-  let nextChapter: number | null = null;
-  let nextVerse: number | null = null;
-  let isFirstVerseOfGenesis: boolean;
-  let isLastVerseOfRevalation: boolean;
-
-  isFirstVerseOfGenesis = false;
-  isLastVerseOfRevalation = false;
-
-  if (book === 'GEN' && chapter === 1 && verse === 1) {
-    isFirstVerseOfGenesis = true;
-  }
-
-  if (book === 'REV' && chapter === 22 && verse === 21) {
-    isLastVerseOfRevalation = true;
-  }
-
-  // Defaults
-  previousBook = book;
-  previousChapter = chapter;
-  nextBook = book;
-  nextChapter = chapter;
-
-  if (verse === 1) {
-    previousVerse = previousChapterData?.verses.length - 1;
-    previousBook = chapterData.previousBookId;
-    previousChapter = chapterData.previousChapterNumber;
-  } else {
-    previousVerse = verse - 1;
-  }
-
-  if (verse === chapterData.verses.length - 1) {
-    nextVerse = 1;
-    nextBook = chapterData.nextBookId;
-    nextChapter = chapterData.nextChapterNumber;
-  } else {
-    nextVerse = verse + 1;
-  }
-
-  return {
-    previousBook,
-    previousChapter,
-    previousVerse,
-    nextBook,
-    nextChapter,
-    nextVerse,
-    isFirstVerseOfGenesis,
-    isLastVerseOfRevalation
-  };
-}
-
-export const BibleVerseParallel = ({ parallels, chapterData, previousChapterData }: BibleVerseParallelProps) => {
-  const contextData = JSON.parse(parallels.contextJson);
-  const navigation = calculateVerseNavigation(
-    parallels.book,
-    parallels.chapter,
-    parallels.verse,
-    chapterData,
-    previousChapterData,
-  );
-
-  const reference = `${OsisToBookName[parallels.book as keyof typeof OsisToBookName]
-    } ${parallels.chapter}:${parallels.verse}`;
-
-  // Build previous verse URL
-  const previousUrl = navigation.previousBook && navigation.previousChapter && navigation.previousVerse
-    ? `/bible/parallel/${navigation.previousBook}/${navigation.previousChapter}/${navigation.previousVerse}`
-    : '#';
-
-  // Build next verse URL  
-  const nextUrl = navigation.nextBook && navigation.nextChapter && navigation.nextVerse
-    ? `/bible/parallel/${navigation.nextBook}/${navigation.nextChapter}/${navigation.nextVerse}`
-    : '#';
-
+export const BibleVerseParallel = ({ parallels }: BibleVerseParallelProps) => {
   return (
-    <div>
-      {/* Browse Links */}
-      <div className="flex w-full min-h-16 items-center justify-center space-x-14 md:space-x-24 mb-4">
-
-        {!navigation.isFirstVerseOfGenesis && (
-          <Link to={previousUrl} >
-            <IconContext.Provider
-              value={{
-                className:
-                  'w-6 h-6 md:w-7 md:h-7 text-neutral-600 dark:text-neutral-200',
-              }}
-            >
-              <FaRegArrowAltCircleLeft />
-            </IconContext.Provider>
-          </Link>
-        )}
-
-        <span className="text-2xl md:text-3xl text-center">{reference}</span>
-
-        {!navigation.isLastVerseOfRevalation && (
-          <Link to={nextUrl} >
-            <IconContext.Provider
-              value={{
-                className:
-                  'w-6 h-6 md:w-7 md:h-7 text-neutral-600 dark:text-neutral-200',
-              }}
-            >
-              <FaRegArrowAltCircleRight />
-            </IconContext.Provider>
-          </Link>
-        )}
-
-      </div>
-
+    <>
       {/* Verse Translations */}
       {parallels.verses.map((verse, index) => {
         return (
@@ -160,6 +23,6 @@ export const BibleVerseParallel = ({ parallels, chapterData, previousChapterData
           </div>
         );
       })}
-    </div>
+    </>
   );
 };

--- a/app/components/breadcrumbs.tsx
+++ b/app/components/breadcrumbs.tsx
@@ -137,7 +137,7 @@ function buildBibleCrumbs(crumbs: string[], nav: NavCrumb[]): NavCrumb[] {
         // verse
         if (crumbs.length > 4) {
           nav.push({
-            name: `Verse ${crumbs[3]}`,
+            name: `Verse ${crumbs[4]}`,
             linkTo: `/bible/${translation}/${crumbs[2]}/${crumbs[3]}/${crumbs[4]}`,
           });
         }

--- a/app/routes/bible_.parallel.$book.$chapter_.$verse.tsx
+++ b/app/routes/bible_.parallel.$book.$chapter_.$verse.tsx
@@ -29,6 +29,8 @@ import { BibleVerseParallel } from '~/components/bible-verse-parallel';
 import { CommentaryByVerseTabbed } from '~/components/commentary-verse';
 import { AuthorImage } from '~/components/image-author';
 import { SiSection } from '~/components/section';
+import {calculateVerseNavigation} from "~/common/verse-navigation";
+import {VerseNavigator} from "~/components/bible-verse-navigator";
 
 enum Tabs {
   Scripture = 'Scripture',
@@ -115,14 +117,46 @@ export default function Index() {
   const [activeTab, setActiveTab] = useState(Tabs.Scripture);
   const uniqueVerseKey = `${parallels.book}-${parallels.chapter}-${parallels.verse}`;
 
+  const navigation = calculateVerseNavigation(
+      parallels.book,
+      parallels.chapter,
+      parallels.verse,
+      chapterData,
+      previousChapterData,
+  );
+
+  const reference = `${OsisToBookName[parallels.book as keyof typeof OsisToBookName]
+  } ${parallels.chapter}:${parallels.verse}`;
+
+  // Build previous verse URL
+  const previousUrl = navigation.previousBook && navigation.previousChapter && navigation.previousVerse
+      ? `/bible/parallel/${navigation.previousBook}/${navigation.previousChapter}/${navigation.previousVerse}`
+      : '#';
+
+  // Build next verse URL
+  const nextUrl = navigation.nextBook && navigation.nextChapter && navigation.nextVerse
+      ? `/bible/parallel/${navigation.nextBook}/${navigation.nextChapter}/${navigation.nextVerse}`
+      : '#';
+
   return (
     <SiPage>
       {/* Desktop View */}
       <div className="w-full hidden lg:block pb-8">
+
+        <VerseNavigator
+            book={parallels.book}
+            chapter={parallels.chapter}
+            verse={parallels.verse}
+            previousUrl={previousUrl}
+            nextUrl={nextUrl}
+            showPrevious={!navigation.isFirstVerseOfGenesis}
+            showNext={!navigation.isLastVerseOfRevelation}
+        />
+
         <div className="grid grid-cols-3">
           <div className="col-span-2">
             <SiSection title="Verse">
-              <BibleVerseParallel parallels={parallels} chapterData={chapterData} previousChapterData={previousChapterData} />
+              <BibleVerseParallel parallels={parallels} />
             </SiSection>
           </div>
           <div>
@@ -176,6 +210,16 @@ export default function Index() {
 
       {/* Mobile View */}
       <div className="lg:hidden block">
+        <VerseNavigator
+            book={parallels.book}
+            chapter={parallels.chapter}
+            verse={parallels.verse}
+            previousUrl={previousUrl}
+            nextUrl={nextUrl}
+            showPrevious={!navigation.isFirstVerseOfGenesis}
+            showNext={!navigation.isLastVerseOfRevelation}
+        />
+
         <VerseContext
           key={uniqueVerseKey}
           context={verseContext}
@@ -201,7 +245,7 @@ export default function Index() {
             active={activeTab === Tabs.Scripture}
             className="py-4 px-2 md:p-4"
           >
-            <BibleVerseParallel parallels={parallels} chapterData={chapterData} previousChapterData={previousChapterData} />
+            <BibleVerseParallel parallels={parallels} />
           </TabContent>
 
           {/* <TabContent

--- a/app/routes/bible_.parallel.$book.$chapter_.$verse.tsx
+++ b/app/routes/bible_.parallel.$book.$chapter_.$verse.tsx
@@ -113,6 +113,7 @@ export default function Index() {
   const verseContext = JSON.parse(parallels.contextJson) as ChapterData;
 
   const [activeTab, setActiveTab] = useState(Tabs.Scripture);
+  const uniqueVerseKey = `${parallels.book}-${parallels.chapter}-${parallels.verse}`;
 
   return (
     <SiPage>
@@ -127,6 +128,7 @@ export default function Index() {
           <div>
             <SiSection title="Context">
               <VerseContext
+                key={uniqueVerseKey}
                 context={verseContext}
                 book={parallels.book}
                 chapter={parallels.chapter}
@@ -175,6 +177,7 @@ export default function Index() {
       {/* Mobile View */}
       <div className="lg:hidden block">
         <VerseContext
+          key={uniqueVerseKey}
           context={verseContext}
           book={parallels.book}
           chapter={parallels.chapter}


### PR DESCRIPTION
We need to key off a unique key for the verse context so the react component is reloaded on a different verse route.

This fixes the awkward verse number artifacts at the start of the verse context section.

Leaving as Draft because I'd like to move the verse title to the top of the page so it's navigation works on mobile with other tabs open (and will match the chapter view).